### PR TITLE
Fix linter

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  singleQuote: true
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lerna": "^2.11.0",
     "prettier": "^1.14.3",
     "tslint": "^5.10.0",
+    "tslint-config-prettier": "^1.15.0",
     "tslint-config-semistandard": "^7.0.0",
     "typescript": "^2.9.2"
   }

--- a/package.json
+++ b/package.json
@@ -13,16 +13,17 @@
   },
   "scripts": {
     "build": "lerna exec yarn build --scope @chronoscio/app",
-    "lint": "tslint packages/**/*.tsx?",
+    "lint": "prettier -l 'packages/**/*.{ts,tsx}' && tslint 'packages/**/*.{ts,tsx}'",
+    "lint:fix": "prettier --write 'packages/**/*.ts' && tslint 'packages/**/*.{ts,tsx}' --fix",
     "now-start": "lerna exec yarn now-start --scope @chronoscio/app",
     "start": "lerna exec yarn start --scope @chronoscio/app",
     "test": "echo Skipped for now."
   },
   "devDependencies": {
     "lerna": "^2.11.0",
+    "prettier": "^1.14.3",
     "tslint": "^5.10.0",
-    "tslint-config-prettier": "^1.14.0",
-    "tslint-react": "^3.6.0",
+    "tslint-config-semistandard": "^7.0.0",
     "typescript": "^2.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "lerna exec yarn build --scope @chronoscio/app",
     "lint": "prettier -l 'packages/**/*.{ts,tsx}' && tslint 'packages/**/*.{ts,tsx}'",
-    "lint:fix": "prettier --write 'packages/**/*.ts' && tslint 'packages/**/*.{ts,tsx}' --fix",
+    "lint:fix": "prettier --write 'packages/**/*.{ts,tsx}' && tslint 'packages/**/*.{ts,tsx}' --fix",
     "now-start": "lerna exec yarn now-start --scope @chronoscio/app",
     "start": "lerna exec yarn start --scope @chronoscio/app",
     "test": "echo Skipped for now."

--- a/packages/app/components/Login/LoggedInMenu/Avatar/Avatar.tsx
+++ b/packages/app/components/Login/LoggedInMenu/Avatar/Avatar.tsx
@@ -6,7 +6,11 @@ import withAuth, { WithAuthProps } from '../../decorators/withAuth';
  * Show the avatar of a user.
  */
 const Avatar: React.SFC<WithAuthProps> = ({ loggedInUser }) => (
-  <Image circular={true} size="mini" src={loggedInUser && loggedInUser.picture} />
+  <Image
+    circular={true}
+    size="mini"
+    src={loggedInUser && loggedInUser.picture}
+  />
 );
 
 export default withAuth(Avatar);

--- a/packages/app/components/Login/decorators/withAuth.ts
+++ b/packages/app/components/Login/decorators/withAuth.ts
@@ -1,10 +1,13 @@
 import { Auth0DecodedHash, Auth0UserProfile } from 'auth0-js';
-import { combineLatest } from 'rxjs/operators';
-import { compose, mapPropsStream, withPropsOnChange } from 'recompose';
+import { combineLatest, startWith, switchMap } from 'rxjs/operators';
+import {
+  compose,
+  mapPropsStream,
+  setObservableConfig,
+  withPropsOnChange
+} from 'recompose';
 import { from, Observable } from 'rxjs';
 import * as localForage from 'localforage';
-import { setObservableConfig } from 'recompose';
-import { startWith, switchMap } from 'rxjs/operators';
 import 'localforage-observable';
 
 // Set recompose to use RxJS

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["tslint-react", "tslint-config-prettier"]
+  "extends": ["tslint-config-semistandard", "tslint-config-prettier"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2199,6 +2199,13 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+doctrine@0.7.2, doctrine@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-0.7.2.tgz#7cb860359ba3be90e040b26b729ce4bfa654c523"
+  dependencies:
+    esutils "^1.1.6"
+    isarray "0.0.1"
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -2442,6 +2449,10 @@ esrecurse@^4.1.0:
 estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+
+esutils@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-1.1.6.tgz#c01ccaa9ae4b897c6d0c3e210ae52f3c7a844375"
 
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
@@ -5015,6 +5026,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.14.3:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
+
 private@^0.1.6:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -6339,19 +6354,42 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
+
+tslib@^1.0.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
-tslint-config-prettier@^1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.14.0.tgz#860b36634e53f4c70c64c51ff3ef7fd9bbab7676"
-
-tslint-react@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/tslint-react/-/tslint-react-3.6.0.tgz#7f462c95c4a0afaae82507f06517ff02942196a1"
+tslint-config-semistandard@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-semistandard/-/tslint-config-semistandard-7.0.0.tgz#c2d3214b6282a4fed07e875dd9f0691be4e832f1"
   dependencies:
-    tsutils "^2.13.1"
+    tslint-config-standard "^7.0.0"
+    tslint-eslint-rules "^4.1.1"
+
+tslint-config-standard@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-standard/-/tslint-config-standard-7.1.0.tgz#6bcc435a179478e365f6cc62312a561221985760"
+  dependencies:
+    tslint-eslint-rules "^5.3.1"
+
+tslint-eslint-rules@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/tslint-eslint-rules/-/tslint-eslint-rules-4.1.1.tgz#7c30e7882f26bc276bff91d2384975c69daf88ba"
+  dependencies:
+    doctrine "^0.7.2"
+    tslib "^1.0.0"
+    tsutils "^1.4.0"
+
+tslint-eslint-rules@^5.3.1:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz#e488cc9181bf193fe5cd7bfca213a7695f1737b5"
+  dependencies:
+    doctrine "0.7.2"
+    tslib "1.9.0"
+    tsutils "^3.0.0"
 
 tslint@^5.10.0:
   version "5.10.0"
@@ -6370,9 +6408,19 @@ tslint@^5.10.0:
     tslib "^1.8.0"
     tsutils "^2.12.1"
 
-tsutils@^2.12.1, tsutils@^2.13.1:
+tsutils@^1.4.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
+
+tsutils@^2.12.1:
   version "2.27.2"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.27.2.tgz#60ba88a23d6f785ec4b89c6e8179cac9b431f1c7"
+  dependencies:
+    tslib "^1.8.1"
+
+tsutils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.0.0.tgz#0c5070a17a0503e056da038c48b5a1870a50a9ad"
   dependencies:
     tslib "^1.8.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6362,6 +6362,10 @@ tslib@^1.0.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
+tslint-config-prettier@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.15.0.tgz#76b9714399004ab6831fdcf76d89b73691c812cf"
+
 tslint-config-semistandard@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/tslint-config-semistandard/-/tslint-config-semistandard-7.0.0.tgz#c2d3214b6282a4fed07e875dd9f0691be4e832f1"


### PR DESCRIPTION
- Add prettier (VSCode extension is still recommended, but not required anymore, to have nicely formatted code), which only handles formatting.
- On top of prettier, add semistandard, so that our code is semistandard-compliant.

Closes #22.