### PR TITLE
Update API for new response

### DIFF
--- a/packages/api/src/api/politicalEntities.ts
+++ b/packages/api/src/api/politicalEntities.ts
@@ -2,7 +2,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 
 import { PoliticalEntity } from '../models';
 
-const API_ENDPOINT = `${process.env.BACKEND_URL}/nations/`;
+const API_ENDPOINT = `${process.env.BACKEND_URL}/politicalentities/`;
 
 export const politicalEntities = {
   async get(id: string, config?: AxiosRequestConfig): Promise<PoliticalEntity> {

--- a/packages/api/src/models/Territory.ts
+++ b/packages/api/src/models/Territory.ts
@@ -5,7 +5,7 @@ export class Territory {
   public endDate?: Date;
   public geo: Geometry;
   public id: number;
-  public nationId: string;
+  public polentId: string;
   public references: string[];
   public startDate: Date;
 
@@ -14,7 +14,7 @@ export class Territory {
     this.endDate = new Date(value.end_date);
     this.geo = value.geo;
     this.id = value.id;
-    this.nationId = value.nation;
+    this.polentId = value.nation;
     this.references = value.references;
     this.startDate = new Date(value.start_date);
   }

--- a/packages/api/src/models/Territory.ts
+++ b/packages/api/src/models/Territory.ts
@@ -14,7 +14,7 @@ export class Territory {
     this.endDate = new Date(value.end_date);
     this.geo = value.geo;
     this.id = value.id;
-    this.polentId = value.nation;
+    this.polentId = value.entity;
     this.references = value.references;
     this.startDate = new Date(value.start_date);
   }

--- a/packages/app/components/MainMap/decorators/territoriesToFC.ts
+++ b/packages/app/components/MainMap/decorators/territoriesToFC.ts
@@ -18,7 +18,7 @@ export default withPropsOnChange<TerritoriesToFCProps, WithTerritoriesProps>(
       ? featureCollection(
           territories.map(territory => ({
             geometry: territory.geo,
-            properties: { nationId: territory.nationId },
+            properties: { polentId: territory.polentId },
             type: 'Feature' as 'Feature'
           }))
         )

--- a/packages/app/components/MainMap/decorators/withHandleTerritoryClick.ts
+++ b/packages/app/components/MainMap/decorators/withHandleTerritoryClick.ts
@@ -23,13 +23,13 @@ export default withHandlers<WithEditingTerritoryProps, {}>({
     }
 
     // If the feature we clicked doesn't have a nation
-    if (!features[0].properties.nationId) {
+    if (!features[0].properties.polentId) {
       return;
     }
 
     const { day, month, year } = Routes.Router.router.query;
     Routes.Router.pushRoute(
-      `/map/${year}/${month}/${day}/${features[0].properties.nationId}`
+      `/map/${year}/${month}/${day}/${features[0].properties.polentId}`
     );
 
     // Navigate to the correct URL

--- a/packages/app/components/Nation/Territories/Territories.tsx
+++ b/packages/app/components/Nation/Territories/Territories.tsx
@@ -39,7 +39,7 @@ const Territories: React.SFC<TerritoriesProps> = ({
   <List selection={true}>
     {territories ? (
       territories
-        .filter(({ nationId }) => nationId === currentNation)
+        .filter(({ polentId }) => polentId === currentNation)
         .map(({ endDate: endDateFromData, geo, id, startDate }) => {
           // If no endDate is specified, we consider it today
           const endDate = endDateFromData ? endDateFromData : new Date();


### PR DESCRIPTION
chronoscio/backend#30 updated the response of Territory objects to return entities in the `entity` field rather than `nation`.